### PR TITLE
Modify descriptions of multi-label targets for the loss functions

### DIFF
--- a/src/loss_functions/losses.py
+++ b/src/loss_functions/losses.py
@@ -17,7 +17,7 @@ class AsymmetricLoss(nn.Module):
         Parameters
         ----------
         x: input logits
-        y: targets (1-hot vector)
+        y: targets (multi-label binalized vector)
         """
 
         # Calculating Probabilities
@@ -71,7 +71,7 @@ class AsymmetricLossOptimized(nn.Module):
         Parameters
         ----------
         x: input logits
-        y: targets (1-hot vector)
+        y: targets (multi-label binalized vector)
         """
 
         self.targets = y

--- a/src/loss_functions/losses.py
+++ b/src/loss_functions/losses.py
@@ -17,7 +17,7 @@ class AsymmetricLoss(nn.Module):
         Parameters
         ----------
         x: input logits
-        y: targets (multi-label binalized vector)
+        y: targets (multi-label binarized vector)
         """
 
         # Calculating Probabilities
@@ -71,7 +71,7 @@ class AsymmetricLossOptimized(nn.Module):
         Parameters
         ----------
         x: input logits
-        y: targets (multi-label binalized vector)
+        y: targets (multi-label binarized vector)
         """
 
         self.targets = y


### PR DESCRIPTION
Dear authors,

Hello. I'm a machine learning engineer from Japan.
First of all, I would like to thank you for publishing such an excellent paper and codes.

I'd like to make a suggestion about the descriptive comments for `y: targets` to be inputted into the loss function.

It's described as a `1-hot vector`, but I think a 1-hot vector is commonly used to refer to a vector that is 1 in one place and 0 in the rest.
(e.g.) https://deepai.org/machine-learning-glossary-and-terms/one-hot-encoding

I personally didn't feel comfortable with the term `1-hot vector`, since this great ASL targets multi-label targets, and I'm sure there is more than one place where the target is 1.
In fact, scikit-learn makes a clear separation between the representations under the names `OneHotEncoder` and `MultiLabelBinarizer`.
- https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html#sklearn.preprocessing.OneHotEncoder
- https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MultiLabelBinarizer.html#sklearn.preprocessing.MultiLabelBinarizer

I would like to suggest changing the description comment to, for example, `multi-label binalized vector`.
I would appreciate it if you would consider the content of this pull request.

Thank you very much.